### PR TITLE
Add EvoAgent X Obsidian plugin skeleton

### DIFF
--- a/obsidian-evo-agentx-plugin/README.md
+++ b/obsidian-evo-agentx-plugin/README.md
@@ -1,0 +1,20 @@
+# EvoAgent X Obsidian Plugin
+
+This plugin provides a thin frontend for the EvoAgent X backend. It exposes a view inside Obsidian that allows you to send the current note to the backend and display the result.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Building
+
+```bash
+npm run build
+```
+
+The compiled plugin files `main.js` and `manifest.json` can then be copied to your Obsidian vault's plugins folder.

--- a/obsidian-evo-agentx-plugin/manifest.json
+++ b/obsidian-evo-agentx-plugin/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "obsidian-evo-agentx-plugin",
+  "name": "EvoAgent X Frontend",
+  "version": "0.0.1",
+  "minAppVersion": "0.15.0",
+  "description": "Thin frontend to EvoAgent X backend",
+  "author": "Your Name",
+  "authorUrl": "https://github.com/yourname",
+  "main": "main.js"
+}

--- a/obsidian-evo-agentx-plugin/package.json
+++ b/obsidian-evo-agentx-plugin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "obsidian-evo-agentx-plugin",
+  "version": "0.0.1",
+  "description": "Thin frontend to EvoAgent X backend",
+  "scripts": {
+    "dev": "rollup -c -w",
+    "build": "rollup -c"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "rollup": "^3.26.2",
+    "rollup-plugin-terser": "^7.0.2",
+    "tslib": "^2.5.3",
+    "typescript": "^5.2.2",
+    "rollup-plugin-typescript2": "^0.34.1"
+  }
+}

--- a/obsidian-evo-agentx-plugin/rollup.config.js
+++ b/obsidian-evo-agentx-plugin/rollup.config.js
@@ -1,0 +1,20 @@
+import typescript from 'rollup-plugin-typescript2';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: 'src/main.ts',
+  output: {
+    dir: '.',
+    format: 'cjs',
+    sourcemap: 'inline'
+  },
+  external: ['obsidian'],
+  plugins: [
+    typescript(),
+    nodeResolve({ browser: true }),
+    commonjs(),
+    terser()
+  ]
+};

--- a/obsidian-evo-agentx-plugin/src/main.ts
+++ b/obsidian-evo-agentx-plugin/src/main.ts
@@ -1,0 +1,59 @@
+import { Plugin, Notice } from 'obsidian';
+import { EvoAgentSettingTab, DEFAULT_SETTINGS, EvoAgentSettings } from './settings';
+import { VIEW_TYPE_EVO_AGENT, EvoAgentView } from './view';
+
+export default class EvoAgentXPlugin extends Plugin {
+  settings: EvoAgentSettings;
+
+  async onload() {
+    await this.loadSettings();
+
+    try {
+      const res = await fetch(`${this.settings.backendUrl}/status`);
+      if (!res.ok) throw new Error('offline');
+    } catch (e) {
+      new Notice('EvoAgent backend offline');
+    }
+
+    this.registerView(
+      VIEW_TYPE_EVO_AGENT,
+      (leaf) => new EvoAgentView(leaf, this)
+    );
+
+    this.addRibbonIcon('dice', 'Open EvoAgent X', () => {
+      this.activateView();
+    });
+
+    this.addCommand({
+      id: 'open-evo-agent-view',
+      name: 'Open EvoAgent View',
+      callback: () => this.activateView()
+    });
+
+    this.addSettingTab(new EvoAgentSettingTab(this.app, this));
+  }
+
+  onunload() {
+    this.app.workspace.detachLeavesOfType(VIEW_TYPE_EVO_AGENT);
+  }
+
+  async activateView() {
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_EVO_AGENT);
+    if (leaves.length === 0) {
+      await this.app.workspace.getRightLeaf(false).setViewState({
+        type: VIEW_TYPE_EVO_AGENT,
+        active: true
+      });
+    } else {
+      this.app.workspace.revealLeaf(leaves[0]);
+    }
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
+}

--- a/obsidian-evo-agentx-plugin/src/settings.ts
+++ b/obsidian-evo-agentx-plugin/src/settings.ts
@@ -1,0 +1,38 @@
+import { App, PluginSettingTab, Setting } from 'obsidian';
+import type EvoAgentXPlugin from './main';
+
+export interface EvoAgentSettings {
+  backendUrl: string;
+}
+
+export const DEFAULT_SETTINGS: EvoAgentSettings = {
+  backendUrl: 'http://localhost:3000'
+};
+
+export class EvoAgentSettingTab extends PluginSettingTab {
+  plugin: EvoAgentXPlugin;
+
+  constructor(app: App, plugin: EvoAgentXPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+    containerEl.createEl('h2', { text: 'EvoAgent X Settings' });
+
+    new Setting(containerEl)
+      .setName('Backend URL')
+      .setDesc('URL of EvoAgent X backend')
+      .addText(text =>
+        text
+          .setPlaceholder('http://localhost:3000')
+          .setValue(this.plugin.settings.backendUrl)
+          .onChange(async value => {
+            this.plugin.settings.backendUrl = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}

--- a/obsidian-evo-agentx-plugin/src/view.ts
+++ b/obsidian-evo-agentx-plugin/src/view.ts
@@ -1,0 +1,56 @@
+import { ItemView, WorkspaceLeaf, Notice } from 'obsidian';
+import type EvoAgentXPlugin from './main';
+
+export const VIEW_TYPE_EVO_AGENT = 'evo-agent-view';
+
+export class EvoAgentView extends ItemView {
+  private outputEl: HTMLElement | null = null;
+  plugin: EvoAgentXPlugin;
+
+  constructor(leaf: WorkspaceLeaf, plugin: EvoAgentXPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return VIEW_TYPE_EVO_AGENT;
+  }
+
+  getDisplayText(): string {
+    return 'EvoAgent X';
+  }
+
+  async onOpen() {
+    const container = this.containerEl;
+    container.empty();
+    container.createEl('h2', { text: 'EvoAgent X' });
+    const btn = container.createEl('button', { text: 'Run Workflow' });
+    btn.addEventListener('click', () => this.runWorkflow());
+    this.outputEl = container.createEl('pre');
+  }
+
+  async runWorkflow() {
+    const file = this.app.workspace.getActiveFile();
+    if (!file) {
+      new Notice('No active file');
+      return;
+    }
+    const content = await this.app.vault.read(file);
+    try {
+      const resp = await fetch(`${this.plugin.settings.backendUrl}/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content })
+      });
+      const text = await resp.text();
+      if (this.outputEl) this.outputEl.textContent = text;
+    } catch (err) {
+      new Notice('Failed to run workflow');
+      console.error(err);
+    }
+  }
+
+  async onClose() {
+    // nothing
+  }
+}

--- a/obsidian-evo-agentx-plugin/tsconfig.json
+++ b/obsidian-evo-agentx-plugin/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "esnext",
+    "lib": ["es6", "dom"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": "./",
+    "strict": true,
+    "sourceMap": true,
+    "inlineSources": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add minimal `obsidian-evo-agentx-plugin` scaffolding
- implement plugin view, settings, and main logic
- configure build with Rollup and TypeScript

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c88eebf1883268ff0508c6f8ea77f